### PR TITLE
CI: add Ruby 3.0, 3.1 to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 2.7, 2.6, 2.5, 2.4, head ]
+        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, 2.4, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This PR extends the build matrix. 