### PR TITLE
README: use GitHub Actions build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SDBM
 
-[![Build Status](https://travis-ci.org/ruby/sdbm.svg?branch=enable-travis)](https://travis-ci.org/ruby/sdbm)
+[![test](https://github.com/ruby/sdbm/actions/workflows/test.yml/badge.svg)](https://github.com/ruby/sdbm/actions/workflows/test.yml)
 
 SDBM provides a simple file-based key-value store, which can only store  String keys and values.
 


### PR DESCRIPTION
This change the build status badge to the CI actually in use.